### PR TITLE
Dem tanks. Dem tanks are niceeeee.

### DIFF
--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Propulsion/ca_tank_lfo80.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Propulsion/ca_tank_lfo80.cfg
@@ -1,0 +1,56 @@
+PART
+{
+    name = ca_tank_lfo80
+    module = Part
+    author = Akron
+
+    MODEL
+    {
+        model = Coatl Aerospace/ProbesPlus/Assets/ca_tank_lfo80
+    }
+    scale = 1
+    rescaleFactor = 1
+    
+    node_stack_bottom = 0.0, -0.475, 0.0, 0.0, -1.0, 0.0, 1
+    node_stack_internal = 0.0, -0.400, 0.0, 0.0, 1.0, 0.0, 0
+    node_stack_top = 0.0, 0.400, 0.0, 0.0, 1.0, 0.0, 1 
+
+    // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+    attachRules = 1,1,1,1,0
+    
+    TechRequired = propulsionSystems
+    entryCost = 2000
+    cost = 150
+    category = FuelTank
+    subcategory = 0
+    title = CA-LT80 “Double” Liquid Fuel Tank
+    manufacturer = Coatl Aerospace
+    description = Holds two liquids for the price of one. Drinking either = Not Recommended. Can be attached inside or outside the probe.
+    
+    mass = 0.05
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 6
+    maxTemp = 2000 // = 3600
+    breakingForce = 50
+    breakingTorque = 50
+    bulkheadProfiles = size1
+    
+    tags = coatl ca lahar lfo liquid fuel propuls rocket vacuum
+
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 36
+        maxAmount = 36
+    }
+    RESOURCE
+    {
+        name = Oxidizer
+        amount = 44
+        maxAmount = 44
+    }
+}
+

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Propulsion/ca_tank_mp170.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Propulsion/ca_tank_mp170.cfg
@@ -1,0 +1,50 @@
+PART
+{
+    name = ca_tank_mp170
+    module = Part
+    author = Akron
+
+    MODEL
+    {
+        model = Coatl Aerospace/ProbesPlus/Assets/ca_tank_mp170
+    }
+    scale = 1
+    rescaleFactor = 1
+    
+    node_stack_bottom = 0.0, -0.475, 0.0, 0.0, -1.0, 0.0, 1
+    node_stack_internal = 0.0, -0.400, 0.0, 0.0, 1.0, 0.0, 0 
+    node_stack_top = 0.0, 0.400, 0.0, 0.0, 1.0, 0.0, 1
+    
+    // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+    attachRules = 1,1,1,1,0
+    
+    TechRequired = precisionPropulsion
+    entryCost = 2000
+    cost = 150
+    category = FuelTank
+    subcategory = 0
+    title = CA-MT170 “Single” MonoPropellant Fuel Tank
+    manufacturer = Coatl Aerospace
+    description = Holds a large amount of a single liquid. Can be attached inside or outside the probe. Not recommended for use in baking.  
+
+    mass = 0.1
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 6
+    maxTemp = 2000 // = 3600
+    breakingForce = 50
+    breakingTorque = 50
+    bulkheadProfiles = size1
+    
+    tags = coatl ca trident monoprop fuel propuls rocket vacuum
+
+    RESOURCE
+    {
+        name = MonoPropellant
+        amount = 170
+        maxAmount = 170
+    }
+}
+


### PR DESCRIPTION
So I did a thing. The models are great, I really like the style. I don't know if the LFO tank is intended to be convertible internal/stack as well, but, well, it kinda is now. The descriptions are certainly off the cuff, as are the names and model numbers.

I have a difficult time with balance though, as my current save is on 6.4x + SMURFF, which makes engine balancing a bit hairy. The MP combo though seems as if it has much more capability/dV despite the MP engine being much heavier than the LFO engine, and not as efficient. It's additionally skewed by any onboard MP the probe might have; I don't know if that ought to be included in balancing or not.

Anyway, it's a lot easier to tune things once they're in game, right? :3  

--komodo
