### PR TITLE
ACS/AACS need to set ModuleSAS.standalone = true

### DIFF
--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Control/aacs.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Control/aacs.cfg
@@ -48,5 +48,6 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 3
+		standalone = True
 	}
 }

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Control/startrack.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Control/startrack.cfg
@@ -42,5 +42,6 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 1
+		standalone = True
 	}
 }


### PR DESCRIPTION
Without standalone the SAS functionality is inaccessible because there is no ModuleCommand in these parts.
