### PR TITLE
Missing rerunnable flag from BDB patch

### DIFF
--- a/GameData/Coatl Aerospace/ProbesPlus/Compatibility/Bluedog_DB.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Compatibility/Bluedog_DB.cfg
@@ -18,6 +18,7 @@
 		dataIsCollectable = True
 		collectActionName = Collect Data
 		interactionRange = 1.2
+		rerunnable = True
 		usageReqMaskInternal = 1
 		usageReqMaskExternal = 8
 	}
@@ -39,6 +40,7 @@
 		dataIsCollectable = True
 		collectActionName = Collect Data
 		interactionRange = 1.2
+		rerunnable = True
 		usageReqMaskInternal = 1
 		usageReqMaskExternal = 8
 	}


### PR DESCRIPTION
IR Spectrometer and IR camera on science boom incorrectly set to run once if Bluedog Design Bureau is installed.