### PR TITLE
Increase maxPressure to survive Venus surface

### DIFF
--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
@@ -36,7 +36,7 @@ PART
 	angularDrag = 1.5
 	crashTolerance = 65
 	maxTemp = 2800 // = 1200
-	maxPressure = 10500
+	maxPressure = 12000
 	gTolerance = 450
 	explosionPotential = 0
 	vesselType = Probe

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
@@ -36,6 +36,7 @@ PART
 	angularDrag = 1.5
 	crashTolerance = 65
 	maxTemp = 2800 // = 1200
+	maxPressure = 10500
 	explosionPotential = 0
 	vesselType = Probe
 	bulkheadProfiles = size0

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
@@ -37,6 +37,7 @@ PART
 	crashTolerance = 65
 	maxTemp = 2800 // = 1200
 	maxPressure = 10500
+	gTolerance = 450
 	explosionPotential = 0
 	vesselType = Probe
 	bulkheadProfiles = size0

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_fom_solar.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_fom_solar.cfg
@@ -32,6 +32,7 @@ PART
 	angularDrag = 1
 	crashTolerance = 10
 	maxTemp = 1200 // = 1200
+	maxPressure = 10500
 	
 	bulkheadProfiles = srf
 

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_fom_solar.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_fom_solar.cfg
@@ -33,6 +33,7 @@ PART
 	crashTolerance = 10
 	maxTemp = 1200 // = 1200
 	maxPressure = 10500
+	gTolerance = 450
 	
 	bulkheadProfiles = srf
 

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_fom_solar.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_fom_solar.cfg
@@ -32,7 +32,7 @@ PART
 	angularDrag = 1
 	crashTolerance = 10
 	maxTemp = 1200 // = 1200
-	maxPressure = 10500
+	maxPressure = 12000
 	gTolerance = 450
 	
 	bulkheadProfiles = srf


### PR DESCRIPTION
10500 kPa = 103.6 atm, enough to survive Venus surface (96 atm) plus a little extra.

h/t to @PhineasFreak: https://github.com/KSP-RO/RealismOverhaul/blob/68b29cf1b3c4a9bb0429bfa522fcbefa13f03459/GameData/RealismOverhaul/RO_SuggestedMods/CoatlAerospace/RO_CA_ProbesPlus_Command.cfg#L507