### PR TITLE
Suggested antenna balance tweaks

### DIFF
--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Antenna/dish_S.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Antenna/dish_S.cfg
@@ -42,7 +42,7 @@ PART
 		antennaType = DIRECT
 		packetInterval = 0.35
 		packetSize = 1
-		packetResourceCost = 24.0
+		packetResourceCost = 6.0
 		requiredResource = ElectricCharge
 		antennaPower = 2500000000
 		antennaCombinable = True

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Meridiani/_Draco.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Meridiani/_Draco.cfg
@@ -116,9 +116,9 @@ PART
 	{
 		name = ModuleDataTransmitter
 		antennaType = DIRECT
-		packetInterval = 0.6
-		packetSize = 2.2
-		packetResourceCost = 5.0
+		packetInterval = 1.0
+		packetSize = 1.8
+		packetResourceCost = 10.0
 		requiredResource = ElectricCharge
 		antennaPower = 550000
 		optimumRange = 5500

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/Fomalhaut.cfg
@@ -117,9 +117,9 @@ PART
 	{
 		name = ModuleDataTransmitter
 		antennaType = DIRECT
-		packetInterval = 0.6
-		packetSize = 2.2
-		packetResourceCost = 6.0
+		packetInterval = 1.0
+		packetSize = 1.8
+		packetResourceCost = 10.0
 		requiredResource = ElectricCharge
 		antennaPower = 550000
 		optimumRange = 5500

--- a/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_vor_dish.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Parts/Vorona/ca_vor_dish.cfg
@@ -27,7 +27,7 @@ PART
 	manufacturer = Coatl Aerospace East
 	description = The Vorona dish has a powerful transmitter for its size, that should allow a fair bit of range in communication in the inner solar system; whether you want it to or not.
 
-	mass = 0.1
+	mass = 0.2
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -43,7 +43,7 @@ PART
 		antennaType = RELAY
 		packetInterval = 0.35
 		packetSize = 1
-		packetResourceCost = 24.0
+		packetResourceCost = 6.0
 		requiredResource = ElectricCharge
 		antennaPower = 3000000000
 		antennaCombinable = True


### PR DESCRIPTION
I've been doing antenna comparisons and found a few outliers.  These are the values without RemoteTech installed.

#### CA-A100 Small Dish Antenna  
EC/Mit value was much higher compared to other antennas.
- EC/s: 68.57 -> 17.14
- Mit/s: 2.86 -> 2.86
- EC/Mit: 24.00 -> 6.00

#### CAE-102 Vorona Dish Antenna  
EC/Mit value was much higher compared to other antennas.  Mass was low compared to stock RA-2.
- EC/s: 68.57 -> 17.14
- Mit/s: 2.86 -> 2.86
- EC/Mit: 24.00 -> 6.00
- Mass: 0.1 -> 0.2

#### CA-L1200 'Draco' / CAE-L165 'Fomalhaut' probes  
Efficiency (EC/Mit) was too good.  Slowed down speed a bit since these are probe cores and not dedicated antennas.
- EC/s: 10.00 -> 10.00
- Mit/s: 3.67 -> 1.80
- EC/Mit: 2.73 -> 5.56

---

Original values compared against the other Coatl's:

![image](https://user-images.githubusercontent.com/11258412/42471311-3e7438b2-838b-11e8-9363-deab06b98943.png)

https://docs.google.com/spreadsheets/d/1yj08CJX458ZbHOsLgVckEtqvHUj5KkP1En-R1kLIYyw/edit#gid=1416012780
