### PR TITLE
add KerbalGPS support for ca_ant_gps

### DIFF
--- a/GameData/Coatl Aerospace/ProbesPlus/Compatibility/KerbalGPS.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Compatibility/KerbalGPS.cfg
@@ -1,0 +1,13 @@
+@PART[ca_ant_gps]:NEEDS[KerbalGPS]
+{
+	MODULE
+	{
+		name = ModuleGPSTransmitter
+		gpsRange = 2000000
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.05
+		}
+	}
+}


### PR DESCRIPTION
Adds a ModuleGPSTransmitter to the part CA-KPS KerbNet Position System Antenna.