### PR TITLE
Update BDB and DMagic patches

### DIFF
--- a/GameData/Coatl Aerospace/ProbesPlus/Compatibility/Bluedog_DB.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Compatibility/Bluedog_DB.cfg
@@ -1,219 +1,221 @@
-//Bluedog Design Bureau Compatibility
+//Bluedog Design Bureau 1.7 Compatibility
 
-//Infra-Red Science
-@PART[mer_rsp]:FOR[CoatlAerospace]:NEEDS[Bluedog_DB]
+// Gamma Rays
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_gammaRay]]]:NEEDS[CoatlAerospace,Bluedog_DB]
 {
-	@MODULE[ModuleScienceExperiment],1
+	@MODULE:HAS[#experimentID[ca_gammaRay]]
 	{
-	@experimentID = bd_IRspec
+		@experimentID = bd_gammaRay
 	}
 }
 
-@PART[ca_KLIR]:FOR[CoatlAerospace]:NEEDS[Bluedog_DB]
+!EXPERIMENT_DEFINITION:HAS[#id[ca_gammaRay]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Radio Plasma Wave Data
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_rpws]]]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience]
 {
-	!MODULE[ModuleScienceExperiment] {}
-	MODULE
+	@MODULE:HAS[#experimentID[ca_rpws]]
 	{
-		name = ModuleScienceExperiment
-		experimentID = bd_IRspec
-		experimentActionName = Observe IR Spectrum
-		resetActionName = Reset Instrument
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 1.0
-		FxModules = 0
-		dataIsCollectable = True
-		collectActionName = Collect Data
-		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
+		@experimentID = bd_rpws
 	}
 }
-@PART[ca_sciBoom]:FOR[CoatlAerospace]:NEEDS[Bluedog_DB]
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_rpws]]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience] {}
+
+// Inrared Spectrometry
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_IRspec]]]:NEEDS[CoatlAerospace,Bluedog_DB]
 {
-	!MODULE[ModuleScienceExperiment],* {}
-	MODULE
+	@MODULE:HAS[#experimentID[ca_IRspec]]
 	{
-		name = ModuleScienceExperiment
-		experimentID = bd_IRspec
-		experimentActionName = Observe IR Spectrum
-		resetActionName = Reset Instrument
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 1.0
-		FxModules = 0
-		dataIsCollectable = True
-		collectActionName = Collect Data
-		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
+		@experimentID = bd_IRspec
 	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_IRspec]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Ionization and Electrostatic Analysis
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_ionElec]]]:NEEDS[CoatlAerospace,Bluedog_DB]
+{
+	@MODULE:HAS[#experimentID[ca_ionElec]]
+	{
+		@experimentID = bd_ionElec
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_ionElec]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Ultraviolet and Atmospheric Analysis
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_UVspec]]]:NEEDS[CoatlAerospace,Bluedog_DB]
+{
+	@MODULE:HAS[#experimentID[ca_UVspec]]
+	{
+		@experimentID = bd_UVspec
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_UVspec]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Solar Wind Measurement
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_solarWind]]]:NEEDS[CoatlAerospace,Bluedog_DB]
+{
+	@MODULE:HAS[#experimentID[ca_solarWind]]
+	{
+		@experimentID = bd_solarWind
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_solarWind]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Micrometeoroid Impact Data
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_micrometeoroid]]]:NEEDS[CoatlAerospace,Bluedog_DB]
+{
+	@MODULE:HAS[#experimentID[ca_micrometeoroid]]
+	{
+		@experimentID = logmmImpacts
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_micrometeoroid]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Radiation Data
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_radsci]]]:NEEDS[CoatlAerospace,Bluedog_DB]
+{
+	@MODULE:HAS[#experimentID[ca_radsci]]
+	{
+		@experimentID = bd_GeigerCounter
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_radsci]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Photographic Image Data
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_filmCamera]]]:NEEDS[CoatlAerospace,Bluedog_DB]
+{
+	@MODULE:HAS[#experimentID[ca_filmCamera]]
+	{
+		@experimentID = bd_camera
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_filmCamera]]:NEEDS[CoatlAerospace,Bluedog_DB] {}
+
+// Magnetometer Data
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_mag]]]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience]
+{
+	@MODULE:HAS[#experimentID[ca_mag]]
+	{
+		@experimentID = bd_magScan
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_mag]]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience] {}
+
+// Orbital Images
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_orbitalScope]]]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience]
+{
+	@MODULE:HAS[#experimentID[ca_orbitalScope]]
+	{
+		@experimentID = bd_orbitalScope
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#ID[ca_orbitalScope]]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience] {}
+
+// Explorer 1 gets UVScope
+@PART[ca_explorer]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience]
+{
 	MODULE
 	{
-		name = ModuleScienceExperiment
-		experimentID = ca_UVspec
-		experimentActionName = Take Ultraviolet Image
-		resetActionName = Delete Data
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = False
-		xmitDataScalar = 0.85
-		dataIsCollectable = True
-		collectActionName = Take Data
+		name = DMModuleScienceAnimateGeneric
+
+		animationName = deploy
+		animSpeed = 1
+		endEventGUIName = Retract
+		showEndEvent = true
+		startEventGUIName = Deploy
+		showStartEvent = true
+		toggleEventGUIName = Toggle
+		showToggleEvent = false
+		showEditorEvents = true
+
+		collectActionName = Collect UV Data
+		dataIsCollectable = true
+		experimentActionName = Take UV Telescope Images
+		experimentID = bd_UVscope
+		hideUIwhenUnavailable = false
 		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
+		rerunnable = true
+		resettableOnEVA = true
+		resourceResetCost = 1
+		resourceToReset = ElectricCharge
+		resetActionName = Reset Experiment
+		reviewActionName = Review Data
+		useActionGroups = True
+		useStaging = False
+		xmitDataScalar = 0.5
+		usageReqMaskExternal = -1
+		customFailMessage = The experiment cannot be performed here
+		deployingMessage = Opening instrument cover
+		experimentWaitForAnimation = true
+		keepDeployedMode = 2
+		waitForAnimationTime = -1
+		oneWayAnimation = false
+		asteroidReports = true
+		externalDeploy = true
+
 		UPGRADES
 		{
 			UPGRADE
 			{
 				name__ = ca-upgrade-optics1
 				description__ = Improves UV camera resolution
-				xmitDataScalar = 0.95
-			}
-		}
-	}
-	MODULE
-	{
-		name = ModuleScienceExperiment
-		experimentID = 	scopeScan
-		experimentActionName = Take Telescope Image
-		resetActionName = Delete Data
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = False
-		xmitDataScalar = 0.85
-		dataIsCollectable = True
-		collectActionName = Take Data
-		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-		UPGRADES
-		{
-			UPGRADE
-			{
-				name__ = ca-upgrade-optics1
-				description__ = Improves telescope resolution
-				xmitDataScalar = 1
+				xmitDataScalar = 1.0
 			}
 		}
 	}
 }
 
-@PART[ca_vor_camera]:FOR[CoatlAerospace]:NEEDS[Bluedog_DB]
+//HOLA Altimeter gets BD altitude science
+@PART[ca_HOLA]:NEEDS[Bluedog_DB]
 {
-	!MODULE[ModuleScienceExperiment],* {}
+	!MODULE[ModuleAnimateGeneric]
 	MODULE
 	{
-		name = ModuleScienceExperiment
-		experimentID = bd_IRspec
-		experimentActionName = Observe IR Spectrum
-		resetActionName = Reset Instrument
-		useStaging = False
+		name = DMModuleScienceAnimateGeneric
+		animationName = deploy
+		animSpeed = 1
+		endEventGUIName = Deactivate Laser
+		showEndEvent = true
+		startEventGUIName = Activate... The Laser!
+		showStartEvent = true
+		toggleEventGUIName = Toggle Laser
+		showToggleEvent = false
+		showEditorEvents = true
+		collectActionName = Collect Altimeter Data
+		dataIsCollectable = true
+		experimentActionName = Perform Scan
+		experimentID = bd_radarAltimeter
+		hideUIwhenUnavailable = false
+		interactionRange = 1.2
+		rerunnable = true
+		resettable = true
+		resettableOnEVA = true
+		resourceResetCost = 1
+		resourceToReset = ElectricCharge
+		resetActionName = Reset Experiment
+		reviewActionName = Review Data
 		useActionGroups = True
-		hideUIwhenUnavailable = True
+		useStaging = False
 		xmitDataScalar = 1.0
-		FxModules = 0
-		dataIsCollectable = True
-		collectActionName = Collect Data
-		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-	MODULE
-	{
-		name = ModuleScienceExperiment
-		experimentID = ca_UVspec
-		experimentActionName = Take Ultraviolet Image
-		resetActionName = Delete Data
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = False
-		xmitDataScalar = 1
-		dataIsCollectable = True
-		collectActionName = Take Data
-		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-	MODULE
-	{
-		name = ModuleScienceExperiment
-		experimentID = 	scopeScan
-		experimentActionName = Take Telescope Image
-		resetActionName = Delete Data
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = False
-		xmitDataScalar = 0.6
-		dataIsCollectable = True
-		collectActionName = Take Data
-		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-		UPGRADES
-		{
-			UPGRADE
-			{
-				name__ = ca-upgrade-optics1
-				description__ = Improves telescope resolution
-				xmitDataScalar = 0.8
-			}
-		}
+		usageReqMaskExternal = -1
+		customFailMessage = The radar altimeter is not suitable for use during atmospheric flight, try again on the ground or in space.
+		deployingMessage = Activate... The Laser!
+		experimentWaitForAnimation = true
+		keepDeployedMode = 2
+		waitForAnimationTime = -1
+		oneWayAnimation = false
+		asteroidReports = true
+		externalDeploy = true
 	}
 }
-//Quetzal Antenna micrometeoroid
-@PART[dish_quetzal]:FOR[CoatlAerospace]:NEEDS[Bluedog_DB]
-{
-	!MODULE[ModuleScienceExperiment] {}
-	MODULE
-	{
-		name = ModuleScienceExperiment
-		experimentID = logmmImpacts
-		experimentActionName = Log Impact Data
-		resetActionName = Discard Impact Data
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = False
-		xmitDataScalar = 1.0
-		dataIsCollectable = True
-		collectActionName = Retrieve Impact Data
-		interactionRange = 1.2
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-}
-//Argo Mast Geiger Counter
-@PART[dish_quetzal]:FOR[CoatlAerospace]:NEEDS[Bluedog_DB]
-{
-	!MODULE[ModuleScienceExperiment],2
-	MODULE
-	{
-		name = ModuleScienceExperiment
-		experimentID = bd_GeigerCounter
-		experimentActionName = Log Radiation
-		resetActionName = Discard Radiation Data
-		useStaging = False
-		useActionGroups = True
-		hideUIwhenUnavailable = True
-		xmitDataScalar = 1.0
-		FxModules = 0
-		dataIsCollectable = True
-		collectActionName = Collect Radiation Data
-		interactionRange = 1.5
-		rerunnable = True
-		usageReqMaskInternal = 1
-		usageReqMaskExternal = 8
-	}
-}
-

--- a/GameData/Coatl Aerospace/ProbesPlus/Compatibility/Bluedog_DB.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Compatibility/Bluedog_DB.cfg
@@ -123,7 +123,7 @@
 !EXPERIMENT_DEFINITION:HAS[#ID[ca_orbitalScope]]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience] {}
 
 // Explorer 1 gets UVScope
-@PART[ca_explorer]:NEEDS[CoatlAerospace,Bluedog_DB,!DMagicOrbitalScience]
+@PART[ca_explorer]:NEEDS[CoatlAerospace,Bluedog_DB]
 {
 	MODULE
 	{
@@ -177,7 +177,7 @@
 }
 
 //HOLA Altimeter gets BD altitude science
-@PART[ca_HOLA]:NEEDS[Bluedog_DB]
+@PART[ca_HOLA]:NEEDS[CoatlAerospace,Bluedog_DB]
 {
 	!MODULE[ModuleAnimateGeneric]
 	MODULE

--- a/GameData/Coatl Aerospace/ProbesPlus/Compatibility/DMagicOrbitalScience.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Compatibility/DMagicOrbitalScience.cfg
@@ -1,281 +1,47 @@
-//*****Magnetometers*****
-
-//Cassini
-@PART[mer_mag]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[DMModuleScienceAnimateGeneric]
-	{
-		@experimentID = magScan
-		@sitMask = 51
-	}
-	MODULE
-	{
-		name = DMMagBoomModule
-
-		runMagnetometer = True
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.05
-		}
-	}
-}
-//Pioneer
-@PART[ca_magneto2]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[DMModuleScienceAnimateGeneric]
-	{
-		@experimentID = magScan
-		@sitMask = 51
-	}
-	MODULE
-	{
-		name = DMMagBoomModule
-
-		runMagnetometer = True
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.05
-		}
-	}
-}
-//Venera
-@PART[ca_vor_mag]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[DMModuleScienceAnimateGeneric]
-	{
-		@experimentID = magScan
-		@sitMask = 51
-	}
-	MODULE
-	{
-		name = DMMagBoomModule
-
-		runMagnetometer = True
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.05
-		}
-	}
-}
-//STEREO
-@PART[ca_stereoBoom]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[DMModuleScienceAnimateGeneric]
-	{
-		@experimentID = magScan
-		@sitMask = 51
-	}
-	MODULE
-	{
-		name = DMMagBoomModule
-
-		runMagnetometer = True
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.05
-		}
-	}
-}
-//MAVEN
-@PART[sp_maven]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[DMModuleScienceAnimateGeneric]
-	{
-		@experimentID = magScan
-		@sitMask = 51
-	}
-	MODULE
-	{
-		name = DMMagBoomModule
-
-		runMagnetometer = True
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.05
-		}
-	}
-}
-//Juno
-@PART[sp_juno_mag]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[DMModuleScienceAnimateGeneric]
-	{
-		@experimentID = magScan
-		@sitMask = 51
-	}
-	MODULE
-	{
-		name = DMMagBoomModule
-
-		runMagnetometer = True
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.05
-		}
-	}
-}
-//Mariner 4
-@PART[ca_argo-mk2-mast]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[ModuleScienceExperiment],1
-	{
-		@experimentID = magScan
-		@sitMask = 51
-	}
-	MODULE
-	{
-		name = DMMagBoomModule
-
-		runMagnetometer = True
-
-		RESOURCE
-		{
-			name	= ElectricCharge
-			rate	= 0.05
-		}
-	}
-}
-
 //*****RPWS*****
 
-//Cassini
-@PART[ca_RPWS]:NEEDS[DMagicOrbitalScience]
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_rpws]]]:NEEDS[CoatlAerospace,DMagicOrbitalScience]
 {
-	!MODULE[DMModuleScienceAnimateGeneric] {}
+	@MODULE[*ModuleScience*]:HAS[#experimentID[ca_rpws]]
+	{
+		@experimentID = rpwsScan
+	}
+}
+
+!EXPERIMENT_DEFINITION:HAS[#id[ca_rpws]]:NEEDS[CoatlAerospace,DMagicOrbitalScience] {}
+
+//*****Magnetometers*****
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_mag]]]:NEEDS[CoatlAerospace,DMagicOrbitalScience]
+{
+	@MODULE[*ModuleScience*]:HAS[#experimentID[ca_mag]]
+	{
+		@experimentID = magScan
+		@sitMask = 51
+	}
 	MODULE
 	{
-    name = DMModuleScienceAnimate
+		name = DMMagBoomModule
+		runMagnetometer = True
 
-    animationName = deploy
-
-	experimentID = rpwsScan
-
-	experimentActionName = Log Radio Plasma Wave Data
-	resetActionName = Discard Data
-
-	customFailMessage = The RPWS Antenna is not suitable for atmospheric use or surface deployment, try again in space.
-	deployingMessage = With the antennae retracted the sensors can't read anything, deploying the system now.
-	experimentAnimation = true
-	experimentWaitForAnimation = true
-	keepDeployedMode = 2
-
-	animSpeed = 1.5
-	showEndEvent = false
-	showStartEvent = false
-	showToggleEvent = true
-	startEventGUIName = Deploy RPWS Antennas
-	endEventGUIName = Retract RPWS Antennas
-	toggleEventGUIName = Toggle RPWS Antennas
-
-	useStaging = False
-	useActionGroups = True
-	hideUIwhenUnavailable = False
-	rerunnable = True
-
-	xmitDataScalar = 1.0
-
-	dataIsCollectable = True
-	collectActionName = Take Data
-	interactionRange = 1.2
-	externalDeploy = True
-	usageReqMaskExternal = 8
+		RESOURCE
+		{
+			name = ElectricCharge
+			rate = 0.05
+		}
 	}
 }
 
-//STEREO
-@PART[ca_RPWS_STEREO]:NEEDS[DMagicOrbitalScience]
+!EXPERIMENT_DEFINITION:HAS[#id[ca_mag]]:NEEDS[CoatlAerospace,DMagicOrbitalScience] {}
+
+//*****Orbital Telescopes*****
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_orbitalScope]]]:NEEDS[CoatlAerospace,DMagicOrbitalScience]
 {
-	!MODULE[DMModuleScienceAnimateGeneric] {}
-	MODULE
-	{
-    name = DMModuleScienceAnimate
-
-    animationName = deploy
-
-	experimentID = rpwsScan
-
-	experimentActionName = Log Radio Plasma Wave Data
-	resetActionName = Discard Data
-
-	customFailMessage = The RPWS Antenna is not suitable for atmospheric use or surface deployment, try again in space.
-	deployingMessage = With the antennae retracted the sensors can't read anything, deploying the system now.
-	experimentAnimation = true
-	experimentWaitForAnimation = true
-	keepDeployedMode = 2
-
-	animSpeed = 1.5
-	showEndEvent = false
-	showStartEvent = false
-	showToggleEvent = true
-	startEventGUIName = Deploy RPWS
-	endEventGUIName = Retract RPWS
-	toggleEventGUIName = Toggle RPWS
-
-	useStaging = False
-	useActionGroups = True
-	hideUIwhenUnavailable = False
-	rerunnable = True
-
-	xmitDataScalar = 0.87
-
-	dataIsCollectable = True
-	collectActionName = Take Data
-	interactionRange = 1.2
-	externalDeploy = True
-	usageReqMaskExternal = 8
-	}
-}
-
-//*****Orbital Telescope*****
-
-//Cassini Remote Sensing Pallet
-@PART[mer_rsp]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[ModuleScienceExperiment],3
+	@MODULE[*ModuleScience*]:HAS[#experimentID[ca_orbitalScope]]
 	{
 		@experimentID = scopeScan
 	}
-
 }
 
-//Hi-Rise
-@PART[ca_telescope_a]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[ModuleScienceExperiment]
-	{
-		@experimentID = scopeScan
-	}
-
-}
-
-//Voyager Science Boom
-@PART[ca_sciBoom]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[ModuleScienceExperiment],3
-	{
-		@experimentID = scopeScan
-	}
-
-}
-
-//Mariner Scan Platform
-@PART[ca_argo-mk4-cam]:NEEDS[DMagicOrbitalScience]
-{
-	@MODULE[ModuleScienceExperiment],3
-	{
-		@experimentID = scopeScan
-	}
-
-}
+!EXPERIMENT_DEFINITION:HAS[#id[ca_orbitalScope]]:NEEDS[CoatlAerospace,DMagicOrbitalScience] {}

--- a/GameData/Coatl Aerospace/ProbesPlus/Compatibility/DMagicOrbitalScience.cfg
+++ b/GameData/Coatl Aerospace/ProbesPlus/Compatibility/DMagicOrbitalScience.cfg
@@ -2,7 +2,7 @@
 
 @PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_rpws]]]:NEEDS[CoatlAerospace,DMagicOrbitalScience]
 {
-	@MODULE[*ModuleScience*]:HAS[#experimentID[ca_rpws]]
+	@MODULE:HAS[#experimentID[ca_rpws]]
 	{
 		@experimentID = rpwsScan
 	}
@@ -14,7 +14,7 @@
 
 @PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_mag]]]:NEEDS[CoatlAerospace,DMagicOrbitalScience]
 {
-	@MODULE[*ModuleScience*]:HAS[#experimentID[ca_mag]]
+	@MODULE:HAS[#experimentID[ca_mag]]
 	{
 		@experimentID = magScan
 		@sitMask = 51
@@ -38,7 +38,7 @@
 
 @PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[ca_orbitalScope]]]:NEEDS[CoatlAerospace,DMagicOrbitalScience]
 {
-	@MODULE[*ModuleScience*]:HAS[#experimentID[ca_orbitalScope]]
+	@MODULE:HAS[#experimentID[ca_orbitalScope]]
 	{
 		@experimentID = scopeScan
 	}


### PR DESCRIPTION
I was making some science patches for Kerbalism and came across some wonkyness due to CA's compatibility patches so I decided to rewrite them.

When the appropriate mod is present the patches now replace the duplicate science experiments with those of BDB/DMagicOrbital and delete the relevant CA experiment definitions to reduce clutter. The BDB patches also take into account the presence of DMagicOrbital.

This covers any mods using CA's science definitions.

Explorer and HOLA get UVScope and BD Altimeter experiment respectively.

:FOR was removed entirely as applying this kind of compatibility patch should happen asap, doesn't necessarily need FIRST though. It was this and the rigid nature of the compatibility patches that came into conflict with Kerbalism.